### PR TITLE
Add l0

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Trainer has `patience` attribute, number of epochs it will for accuracy to improve before 
   stopping training early.
+- add `prep` command to command-line interface, to separate preparing datasets from 
+  training and testing models.
 
 ### Changed
 - use `tensorflow_probability` for distributions

--- a/src/ram/cli.py
+++ b/src/ram/cli.py
@@ -95,10 +95,10 @@ def _call_test(config, configfile, logger, command, dataset_module):
     logger.info("\nRunning main in 'test' mode, will test accuracy of previously trained models\n"
                 "on the test data set.")
 
+    logger.info(f'\nLoading test data from path in {config.data.paths_dict_fname}, ')
     with open(config.data.paths_dict_fname) as fp:
         paths_dict = json.load(fp)
 
-    logger.info(f'\nLoading test data from path in {paths_dict_fname}, ')
     logger.info(f'\nUsing {config.data.module} module to load dataset')
     test_data = dataset_module.get_split(paths_dict, setname=['test'])
     tester = ram.Tester.from_config(config=config, test_data=test_data, logger=logger)

--- a/src/ram/config.py
+++ b/src/ram/config.py
@@ -1,7 +1,10 @@
+import ast
 import os
 from configparser import ConfigParser
 
 import attr
+import numpy as np
+
 
 VALID_OPTIONS = {
     'model': [
@@ -35,6 +38,7 @@ VALID_OPTIONS = {
         'save_loss',
         'save_train_inds',
         'patience',
+        'val_l0',
     ],
     'data': [
         'root_results_dir',
@@ -48,6 +52,7 @@ VALID_OPTIONS = {
     'test': [
         'save_examples',
         'num_examples_to_save',
+        'test_l0',
     ],
     'misc': [
         'save_log',
@@ -128,6 +133,12 @@ class TrainConfig(object):
     patience = attr.ib(converter=attr.converters.optional(int), default=None)
     # user does not specify current replicate, gets changed by main()
     current_replicate = attr.ib(type=int, default=None)
+    val_l0 = attr.ib(converter=attr.converters.optional(ast.literal_eval), default=None)
+
+    def __attrs_post_init__(self):
+        # convert to array so we can broadcast to batch size,
+        # and cast to float32 so Tensorflow doesn't crash
+        self.val_l0 = np.asarray(self.val_l0, dtype=np.float32)
 
 
 @attr.s
@@ -135,6 +146,12 @@ class TestConfig(object):
     """class that represents configuration for testing a RAM model"""
     save_examples = attr.ib(converter=strtobool, default='True')
     num_examples_to_save = attr.ib(converter=attr.converters.optional(int), default=None)
+    test_l0 = attr.ib(converter=attr.converters.optional(ast.literal_eval), default=None)
+
+    def __attrs_post_init__(self):
+        # convert to array so we can broadcast to batch size,
+        # and cast to float32 so Tensorflow doesn't crash
+        self.test_l0 = np.asarray(self.test_l0, dtype=np.float32)
 
 
 @attr.s

--- a/src/ram/trainer.py
+++ b/src/ram/trainer.py
@@ -22,6 +22,8 @@ from tqdm import tqdm
 import attr
 
 from . import ram
+from .ram import StateAndMeta
+
 
 LossesTuple = namedtuple('LossesTuple', ['reinforce_loss',
                                          'baseline_loss',
@@ -46,6 +48,7 @@ class Trainer:
                  optimizers,
                  train_data,
                  val_data=None,
+                 val_l0=None,
                  shuffle_each_epoch=True,
                  patience=None,
                  replicates=1,
@@ -105,6 +108,8 @@ class Trainer:
             self.val_data = None
             self.logger.info(f'Validation data: {self.val_data}')
             self.num_val_samples = None
+
+        self.val_l0 = val_l0
 
         # hyperparams that will be common across replicates
         self.batch_size = batch_size
@@ -188,6 +193,7 @@ class Trainer:
                    optimizers=optimizers,
                    train_data=train_data,
                    val_data=val_data,
+                   val_l0=config.train.val_l0,
                    shuffle_each_epoch=config.train.shuffle_each_epoch,
                    patience=config.train.patience,
                    replicates=config.train.replicates,
@@ -691,6 +697,10 @@ class Trainer:
                 with tqdm(total=self.num_val_samples) as progress_bar:
                     for img, lbl, batch_train_inds in self.val_data.batch(self.batch_size):
                         out_t_minus_1 = self.model.reset()
+                        if self.val_l0 is not None:
+                            l_t = np.broadcast_to(self.val_l0, shape=(self.batch_size, 2))
+                            out_t_minus_1 = StateAndMeta(None, None, out_t_minus_1.h_t, None, l_t, None, None)
+
                         for t in range(self.model.glimpses):
                             out = self.model.step(img, out_t_minus_1.l_t, out_t_minus_1.h_t)
                             out_t_minus_1 = out


### PR DESCRIPTION
adds `val_l0` and `test_l0` attributes to TrainConfig and TestConfig, which are used by Trainer and Tester to have a fixed location for the first time step of every episode run with a RAM model